### PR TITLE
Do not define CGGesturePhase on Sea Lion

### DIFF
--- a/ext/mouse/CGEventAdditions.h
+++ b/ext/mouse/CGEventAdditions.h
@@ -108,7 +108,7 @@ enum {
   kCGGestureTypeGestureEnded   = 62,
 };
 
-
+#if MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_9
 /*!
  * @enum CGGesturePhase
  * @abstract Gesture phases
@@ -127,6 +127,7 @@ enum {
   kCGGesturePhaseEnded     = kIOHIDEventPhaseEnded,
   kCGGesturePhaseCancelled = kIOHIDEventPhaseCancelled,
 };
+#endif
 
 
 /*!


### PR DESCRIPTION
The Sea Lion SDK made GCGesturePhase public so we don't have to
define it when we are linking against 10.9
